### PR TITLE
[OPS-6779] Make new monit versions less verbose

### DIFF
--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -120,7 +120,7 @@ set alert <%= @admin %>                       # receive all alerts
 #
 set httpd port 2812 and
     use address localhost  # only accept connection from localhost
-    allow localhost        # allow localhost to connect to the server and
+    allow 127.0.0.1        # allow localhost to connect to the server and
 #     allow admin:monit      # require user 'admin' with password 'monit'
 #     allow @monit           # allow users of group 'monit' to connect (rw)
 #     allow @users readonly  # allow users of group 'users' to connect readonly


### PR DESCRIPTION
Recent monit versions will output the following when reading the config
"Skipping 'allow localhost' -- host resolved to [::ffff:127.0.0.1] which
is present in ACL already"

In order to avoid that we need to replace "allow localhost" to "allow
127.0.0.1" as described at https://bitbucket.org/tildeslash/monit/issues/424/skipping-redundant-host-localhost